### PR TITLE
Updated to build with Caliper. Modified run script to use Caliper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 	path = MFEM
   url = git@github.com:jonesholger/MFEM.git
   branch = feature/mfem_submodule
+[submodule "tpl/caliper"]
+	path = tpl/caliper
+	url = git@github.com:LLNL/Caliper

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(BLT_CXX_STANDARD 11)
 set(ENABLE_TESTS Off CACHE Bool "")
 set(ENABLE_EXAMPLES Off CACHE Bool "")
 set(ENABLE_DOCUMENTATION Off CACHE Bool "")
+set(ENABLE_CALIPER Off CACHE Bool "")
 
 set(ENABLE_TBB Off CACHE Bool "")
 
@@ -49,9 +50,18 @@ set(RAJA_RANGE_MIN_LENGTH 32)
 set(RAJA_DATA_ALIGN 64)
 set(RAJA_COHERENCE_BLOCK_SIZE 64)
 
-
 # exclude RAJA make targets from top-level build...
 add_subdirectory(tpl/RAJA)
+
+if(ENABLE_CALIPER)
+  set(WITH_SAMPLER Off)
+  set(WITH_NVPROF On)
+  add_definitions("-DLAGHOS_ENABLE_CALIPER")
+  add_subdirectory(tpl/caliper)
+  get_property(CALIPER_INCLUDE_DIRS DIRECTORY tpl/caliper PROPERTY INCLUDE_DIRECTORIES)
+  MESSAGE( STATUS "CALIPER_INCLUDE_DIRS:           " ${CALIPER_INCLUDE_DIRS})
+  include_directories(${CALIPER_INCLUDE_DIRS})
+endif()
 
 get_property(RAJA_INCLUDE_DIRS DIRECTORY tpl/RAJA PROPERTY INCLUDE_DIRECTORIES)
 include_directories(${RAJA_INCLUDE_DIRS})
@@ -75,6 +85,9 @@ set(LAGHOS_VERSION_PATCHLEVEL 0)
 
 set(LAGHOS_DEPENDS RAJA)
 list(APPEND LAGHOS_DEPENDS mfem)
+if(ENABLE_CALIPER)
+list(APPEND LAGHOS_DEPENDS caliper)
+endif()
 
 if (ENABLE_OPENMP)
   list(APPEND LAGHOS_DEPENDS openmp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ add_subdirectory(tpl/RAJA)
 
 if(ENABLE_CALIPER)
   set(WITH_SAMPLER Off)
+  set(WITH_CALLPATH Off)
   set(WITH_NVPROF On)
   add_definitions("-DLAGHOS_ENABLE_CALIPER")
   add_subdirectory(tpl/caliper)

--- a/caliper.config
+++ b/caliper.config
@@ -1,0 +1,9 @@
+# [simpleprofile]
+CALI_SERVICES_ENABLE=aggregate:event:recorder:timestamp
+CALI_TIMER_SNAPSHOT_DURATION=true
+CALI_TIMER_INCLUSIVE_DURATION=false
+CALI_AGGREGATE_KEY=annotation:function
+CALI_EVENT_TRIGGER=annotation:function
+
+# [nvprof]
+CALI_SERVICES_ENABLE=event:trace:nvprof

--- a/scripts/blueos_nvcc9.0_gcc4.9.3.sh
+++ b/scripts/blueos_nvcc9.0_gcc4.9.3.sh
@@ -26,6 +26,8 @@ cmake \
   -C ${LAGHOS_DIR}/host-configs/blueos/nvcc_gcc_4_9_3.cmake \
   -DMFEM_USE_MPI=On \
   -DENABLE_OPENMP=On \
+  -DENABLE_CALIPER=On \
+  -DWITH_NVPROF=On \
   -DENABLE_CUDA=On \
   -DENABLE_CUB=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-9.0.176 \

--- a/scripts/blueos_nvcc9.0_gcc4.9.3.sh
+++ b/scripts/blueos_nvcc9.0_gcc4.9.3.sh
@@ -28,6 +28,7 @@ cmake \
   -DENABLE_OPENMP=On \
   -DENABLE_CALIPER=On \
   -DWITH_NVPROF=On \
+  -DWITH_CALLPATH=Off \
   -DENABLE_CUDA=On \
   -DENABLE_CUB=On \
   -DCUDA_TOOLKIT_ROOT_DIR=/usr/tce/packages/cuda/cuda-9.0.176 \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ blt_add_executable(
   SOURCES laghos.cpp 
   laghos_assembly.cpp
   laghos_solver.cpp
+  profiling.cpp
   DEPENDS_ON ${LAGHOS_EXECUTABLE_DEPENDS}
   )
 

--- a/src/laghos.cpp
+++ b/src/laghos.cpp
@@ -7,6 +7,7 @@
 // element discretizations for exascale applications. For more information and
 // source code availability see http://github.com/ceed.
 //
+//
 // The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
 // a collaborative effort of two U.S. Department of Energy organizations (Office
 // of Science and the National Nuclear Security Administration) responsible for
@@ -50,9 +51,8 @@
 //    p = 2  --> 1D Sod shock tube.
 //    p = 3  --> Triple point.
 
-#include <caliper/Annotation.h>
-#include <caliper/cali_macros.h>
 #include "laghos_solver.hpp"
+#include "profiling.hpp"
 #include <memory>
 #include <iostream>
 #include <fstream>
@@ -94,6 +94,7 @@ int main(int argc, char *argv[])
    bool visit = false;
    bool gfprint = false;
    bool cuda = false;
+   bool profile_cuda = false;
    const char *basename = "results/Laghos";
 
    OptionsParser args(argc, argv);
@@ -136,6 +137,8 @@ int main(int argc, char *argv[])
                   "Name of the visit dump files");
    args.AddOption(&cuda, "-cuda", "--cuda", "-no-cuda", "--no-cuda",
                   "Enable or disable CUDA kernels.");
+   args.AddOption(&profile_cuda, "-profile-cuda", "--profile-cuda", "-no-profile-cuda", "--no-profile-cuda",
+                  "Enable or disable CUDA kernel profiling.");
    args.Parse();
    if (!args.Good())
    {
@@ -146,6 +149,9 @@ int main(int argc, char *argv[])
    
    // Setting the info CUDA kernels are requested
    is_managed=cuda;
+   if(profile_cuda){
+      enableCudaProfiling();
+   }
    
    // Read the serial mesh from the given mesh file on all processors.
    // Refine the mesh in serial to increase the resolution.

--- a/src/laghos.cpp
+++ b/src/laghos.cpp
@@ -50,7 +50,8 @@
 //    p = 2  --> 1D Sod shock tube.
 //    p = 3  --> Triple point.
 
-
+#include <caliper/Annotation.h>
+#include <caliper/cali_macros.h>
 #include "laghos_solver.hpp"
 #include <memory>
 #include <iostream>

--- a/src/laghos_assembly.cpp
+++ b/src/laghos_assembly.cpp
@@ -159,6 +159,7 @@ void RajaForceOperator::Setup()
 // *************************************************************************
 void RajaForceOperator::Mult(const RajaVector &vecL2,
                              RajaVector &vecH1) const {
+   LAGHOS_MARK_FUNCTION
    l2fes.GlobalToLocal(vecL2, gVecL2);
    const int NUM_DOFS_1D = h1fes.GetFE(0)->GetOrder()+1;
    const IntegrationRule &ir1D = IntRules.Get(Geometry::SEGMENT, integ_rule.GetOrder());
@@ -183,6 +184,7 @@ void RajaForceOperator::Mult(const RajaVector &vecL2,
 // *************************************************************************
 void RajaForceOperator::MultTranspose(const RajaVector &vecH1,
                                       RajaVector &vecL2) const {
+   LAGHOS_MARK_FUNCTION
    h1fes.GlobalToLocal(vecH1, gVecH1);
    const int NUM_DOFS_1D = h1fes.GetFE(0)->GetOrder()+1;
    const IntegrationRule &ir1D = IntRules.Get(Geometry::SEGMENT, integ_rule.GetOrder());

--- a/src/laghos_solver.cpp
+++ b/src/laghos_solver.cpp
@@ -30,6 +30,7 @@ void VisualizeField(socketstream &sock, const char *vishost, int visport,
                     ParGridFunction &gf, const char *title,
                     int x, int y, int w, int h, bool vec)
 {
+   LAGHOS_MARK_FUNCTION
    ParMesh &pmesh = *gf.ParFESpace()->GetParMesh();
    MPI_Comm comm = pmesh.GetComm();
 
@@ -170,6 +171,7 @@ LagrangianHydroOperator::~LagrangianHydroOperator() {}
 // *****************************************************************************
 void LagrangianHydroOperator::Mult(const RajaVector &S, RajaVector &dS_dt) const
 {
+   LAGHOS_MARK_FUNCTION
    dS_dt = 0.0;
 
    // Make sure that the mesh positions correspond to the ones in S. This is
@@ -287,6 +289,7 @@ void LagrangianHydroOperator::Mult(const RajaVector &S, RajaVector &dS_dt) const
 
 double LagrangianHydroOperator::GetTimeStepEstimate(const RajaVector &S) const
 {
+   LAGHOS_MARK_FUNCTION
    Vector h_x = RajaVector(S.GetRange(0, H1FESpace.GetVSize()));
    ParGridFunction x(&H1FESpace, h_x.GetData());
    H1FESpace.GetMesh()->NewNodes(x, false);
@@ -305,6 +308,7 @@ void LagrangianHydroOperator::ResetTimeStepEstimate() const
 
 void LagrangianHydroOperator::ComputeDensity(ParGridFunction &rho)
 {
+   LAGHOS_MARK_FUNCTION
    rho.SetSpace(&L2FESpace);
 
    DenseMatrix Mrho(l2dofs_cnt);

--- a/src/laghos_solver.hpp
+++ b/src/laghos_solver.hpp
@@ -19,6 +19,7 @@
 
 #include "mfem.hpp"
 #include "raja/raja.hpp"
+#include <caliper/cali_macros.h>
 
 #include "laghos_assembly.hpp"
 

--- a/src/profiling.cpp
+++ b/src/profiling.cpp
@@ -1,0 +1,12 @@
+#include "profiling.hpp"
+#ifdef LAGHOS_ENABLE_CALIPER
+#include <caliper/cali.h>
+#endif
+void enableCudaProfiling(){
+#ifdef LAGHOS_ENABLE_CALIPER
+  cali_config_preset("CALI_SERVICES_ENABLE","event:trace:nvprof");
+#else
+  std::cerr << "Warning, attempted to enable CUDA profiling without Caliper, ranges will not be visible\n";
+#endif
+}
+

--- a/src/profiling.hpp
+++ b/src/profiling.hpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2017, Lawrence Livermore National Security, LLC. Produced at
+// the Lawrence Livermore National Laboratory. LLNL-CODE-734707. All Rights
+// reserved. See files LICENSE and NOTICE for details.
+//
+// This file is part of CEED, a collection of benchmarks, miniapps, software
+// libraries and APIs for efficient high-order finite element and spectral
+// element discretizations for exascale applications. For more information and
+// source code availability see http://github.com/ceed.
+//
+// The CEED research is supported by the Exascale Computing Project 17-SC-20-SC,
+// a collaborative effort of two U.S. Department of Energy organizations (Office
+// of Science and the National Nuclear Security Administration) responsible for
+// the planning and preparation of a capable exascale ecosystem, including
+// software, applications, hardware, advanced system engineering and early
+// testbed platforms, in support of the nation's exascale computing imperative.
+//
+//                     __                __
+//                    / /   ____  ____  / /_  ____  _____
+//                   / /   / __ `/ __ `/ __ \/ __ \/ ___/
+//                  / /___/ /_/ / /_/ / / / / /_/ (__  )
+//                 /_____/\__,_/\__, /_/ /_/\____/____/
+//                             /____/
+//
+//             High-order Lagrangian Hydrodynamics Miniapp
+//
+// Laghos(LAGrangian High-Order Solver) is a miniapp that solves the
+// time-dependent Euler equation of compressible gas dynamics in a moving
+// Lagrangian frame using unstructured high-order finite element spatial
+// discretization and explicit high-order time-stepping. Laghos is based on the
+// numerical algorithm described in the following article:
+//
+//    V. Dobrev, Tz. Kolev and R. Rieben, "High-order curvilinear finite element
+//    methods for Lagrangian hydrodynamics", SIAM Journal on Scientific
+//    Computing, (34) 2012, pp.B606–B641, https://doi.org/10.1137/120864672.
+//
+// Sample runs:
+//    mpirun -np 8 laghos -p 0 -m data/square01_quad.mesh -rs 3 -tf 0.75
+//    mpirun -np 8 laghos -p 0 -m data/square01_tri.mesh  -rs 1 -tf 0.75
+//    mpirun -np 8 laghos -p 0 -m data/cube01_hex.mesh    -rs 1 -tf 2.0
+//    mpirun -np 8 laghos -p 1 -m data/square01_quad.mesh -rs 3 -tf 0.8
+//    mpirun -np 8 laghos -p 1 -m data/square01_quad.mesh -rs 0 -tf 0.8 -ok 7 -ot 6
+//    mpirun -np 8 laghos -p 1 -m data/cube01_hex.mesh    -rs 2 -tf 0.6
+//    mpirun -np 8 laghos -p 2 -m data/segment01.mesh     -rs 5 -tf 0.2
+//    mpirun -np 8 laghos -p 3 -m data/rectangle01_quad.mesh -rs 2 -tf 2.5
+//    mpirun -np 8 laghos -p 3 -m data/box01_hex.mesh        -rs 1 -tf 2.5
+//
+// Test problems:
+//    p = 0  --> Taylor-Green vortex (smooth problem).
+//    p = 1  --> Sedov blast.
+//    p = 2  --> 1D Sod shock tube.
+//    p = 3  --> Triple point.
+
+#ifndef LAGHOS_PROFILING_HPP
+#define LAGHOS_PROFILING_HPP
+#include<iostream>
+#ifdef LAGHOS_ENABLE_CALIPER
+#include <caliper/Annotation.h>
+#include <caliper/cali_macros.h>
+#ifndef LAGHOS_INSTRUMENT_QUOTE
+#define LAGHOS_INSTRUMENT_QUOTE(x) #x
+#endif
+#define LAGHOS_MARK_FUNCTION cali::Annotation::Guard standard_guard(cali::Annotation("function").begin(__PRETTY_FUNCTION__));
+#else
+#define LAGHOS_MARK_FUNCTION
+#endif
+
+void enableCudaProfiling();
+
+#endif

--- a/src/raja/kernels/raja.hpp
+++ b/src/raja/kernels/raja.hpp
@@ -16,6 +16,7 @@
 #ifndef LAGHOS_RAJA_KERNELS_RAJA
 #define LAGHOS_RAJA_KERNELS_RAJA
 
+#include <profiling.hpp>
 // *****************************************************************************
 #undef NDEBUG
 #include <math.h>

--- a/src/raja/raja.hpp
+++ b/src/raja/raja.hpp
@@ -15,12 +15,6 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 #ifndef LAGHOS_RAJA
 #define LAGHOS_RAJA
-#include <caliper/cali_macros.h>
-#ifdef LAGHOS_ENABLE_CALIPER
-#define LAGHOS_MARK_FUNCTION CALI_CXX_MARK_FUNCTION;
-#else
-#define LAGHOS_MARK_FUNCTION
-#endif
 // DBG *************************************************************************
 //#include "dbg.hpp"
 //#define __dbg__ dbg();
@@ -30,6 +24,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <assert.h>
+#include <profiling.hpp>
 
 // MFEM/fem  *******************************************************************
 #include "fem/gridfunc.hpp"

--- a/src/raja/raja.hpp
+++ b/src/raja/raja.hpp
@@ -15,7 +15,12 @@
 // testbed platforms, in support of the nation's exascale computing imperative.
 #ifndef LAGHOS_RAJA
 #define LAGHOS_RAJA
-
+#include <caliper/cali_macros.h>
+#ifdef LAGHOS_ENABLE_CALIPER
+#define LAGHOS_MARK_FUNCTION CALI_CXX_MARK_FUNCTION;
+#else
+#define LAGHOS_MARK_FUNCTION
+#endif
 // DBG *************************************************************************
 //#include "dbg.hpp"
 //#define __dbg__ dbg();


### PR DESCRIPTION
Basic NVProf profiling added. To enable NVProf ranges from the code, run

[your typical mpirun command] nvprof [stuff] --profile-cuda

Verified this works on Manta, anywhere you want feel free to include profiling.hpp and use LAGHOS_MARK_FUNCTION to add Caliper instrumentation to a function if Caliper is enabled.